### PR TITLE
fix(license): prevent activation failure when changing license keys

### DIFF
--- a/src/Data/License.php
+++ b/src/Data/License.php
@@ -83,7 +83,20 @@ class SC_License extends SC_Data {
         $id  = $post['id'] ?? null;
         $key = $post['license_key'] ?? '';
 
-        return ( new self( $id ) )->set_license_key( $key );
+        $license = new self( $id );
+        
+        // If new license key provided and differs from stored - RESET EVERYTHING
+        if ( $key !== '' && $license->get_license_key() !== $key ) {
+            
+            // Delete old license data from database
+            $license->delete();
+            
+            // Create fresh license with only the new key
+            $license = new self( $id );
+            $license->set_license_key( $key );
+        }
+        
+        return $license;
     }
 
     /**


### PR DESCRIPTION
When a user submits a new license key through the activation form, the system was incorrectly using cached license data (including old license_id and status) from the database instead of registering the new key properly.

This caused:
- Registration step to be skipped (registered=true from old data)
- Activation to fail with "license revoked" error
- Users unable to activate valid new licenses

Solution:
- Enhanced License::from_data() to detect license key changes
- Automatically delete old license data when key differs
- Create fresh license object with only new key
- Forces proper registration → activation flow

Fixes license activation for users switching between different license keys.